### PR TITLE
Use MoveGroupInterface for Kinetic support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(cmake_modules REQUIRED)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 catkin_package(
 )

--- a/src/pick_and_place_test.cpp
+++ b/src/pick_and_place_test.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <stdio.h>
 
-#include <moveit/move_group_interface/move_group.h>
+#include <moveit/move_group_interface/move_group_interface.h>
 
 #include <moveit_msgs/CollisionObject.h>
 #include <moveit_msgs/AttachedCollisionObject.h>
@@ -18,7 +18,7 @@ protected:
     ros::ServiceClient grasp_planning_service;
 
 public:
-    moveit::planning_interface::MoveGroup arm;
+    moveit::planning_interface::MoveGroupInterface arm;
     PickAndPlaceTest() :
         arm("arm")
     {
@@ -32,18 +32,18 @@ public:
     bool executePick(){
         arm.setPlanningTime(20.0);
         arm.setSupportSurfaceName("table");
-        return arm.planGraspsAndPick("object");
+        return bool(arm.planGraspsAndPick("object"));
     }
 
     bool executePick(moveit_msgs::CollisionObject &object){
         arm.setPlanningTime(20.0);
         arm.setSupportSurfaceName("table");
-        return arm.planGraspsAndPick(object);
+        return bool(arm.planGraspsAndPick(object));
     }
 
     void executePlace(){
 
-        moveit::planning_interface::MoveGroup gripper("gripper");
+        moveit::planning_interface::MoveGroupInterface gripper("gripper");
 
         std::vector<moveit_msgs::PlaceLocation> location;
 

--- a/src/pick_place_demo.cpp
+++ b/src/pick_place_demo.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <stdio.h>
 
-#include <moveit/move_group_interface/move_group.h>
+#include <moveit/move_group_interface/move_group_interface.h>
 
 #include <moveit_msgs/CollisionObject.h>
 #include <moveit_msgs/ApplyPlanningScene.h>
@@ -17,8 +17,8 @@ protected:
     ros::ServiceClient planning_scene_diff_client;
     ros::ServiceClient get_planning_scene_client;
 
-    moveit::planning_interface::MoveGroup arm;
-    moveit::planning_interface::MoveGroup gripper;
+    moveit::planning_interface::MoveGroupInterface arm;
+    moveit::planning_interface::MoveGroupInterface gripper;
 
     tf::TransformListener tf_listener;
     tf::StampedTransform transform;
@@ -44,7 +44,7 @@ public:
 
     bool executePick(){
         arm.setSupportSurfaceName("table");
-        return arm.planGraspsAndPick("can");
+        return bool(arm.planGraspsAndPick("can"));
     }
 
     
@@ -154,14 +154,12 @@ public:
 
     bool placeStub(){
         arm.setPoseTarget(place_pose,"s_model_tool0");
-        return arm.move();
-        return false;
+        return bool(arm.move());
     }
 
     bool releaseObject(){
-
         gripper.setNamedTarget("open");
-        return gripper.move();
+        return bool(gripper.move());
     }
 
     void resetPlacePose(){

--- a/src/plan_grasps_service.cpp
+++ b/src/plan_grasps_service.cpp
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 #include <moveit_msgs/GraspPlanning.h>
 
-#include <moveit/move_group_interface/move_group.h>
+#include <moveit/move_group_interface/move_group_interface.h>
 
 void jointValuesToJointTrajectory(std::map<std::string, double> target_values, ros::Duration duration, 
         trajectory_msgs::JointTrajectory &grasp_pose)
@@ -19,8 +19,8 @@ void jointValuesToJointTrajectory(std::map<std::string, double> target_values, r
 
 bool serviceCB(moveit_msgs::GraspPlanning::Request &req, moveit_msgs::GraspPlanning::Response &res)
 {
-  moveit::planning_interface::MoveGroup move_group(req.group_name);
-  moveit::planning_interface::MoveGroup gripper(move_group.getRobotModel()->getEndEffectors()[0]->getName());
+  moveit::planning_interface::MoveGroupInterface move_group(req.group_name);
+  moveit::planning_interface::MoveGroupInterface gripper(move_group.getRobotModel()->getEndEffectors()[0]->getName());
 
   moveit_msgs::Grasp grasp;
   grasp.id = "grasp";


### PR DESCRIPTION
Exchanges all deprecated references to MoveGroup with MoveGroupInterface.
Since MoveItErrorCodes are not evaluated to bool by default, the bool() operator is added at each call to evaluate for success.

The change from Eigen to Eigen3 as package dependency resolves a build error that occurred when compiling for kinetic in combination with the flag CMAKE_CXX_STANDARD set to 11.